### PR TITLE
[BUGFIX] autoParagraph and enterMode

### DIFF
--- a/Classes/EventListener/AfterTransformTextForPersistence.php
+++ b/Classes/EventListener/AfterTransformTextForPersistence.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace B13\Richtextinputfields\EventListener;
+
+use TYPO3\CMS\Core\Attribute\AsEventListener;
+use TYPO3\CMS\Core\Html\Event\AfterTransformTextForPersistenceEvent;
+
+#[AsEventListener(
+    identifier: 'b13/richtextinputfields/afterTransformTextForPersistence'
+)]
+class AfterTransformTextForPersistence
+{
+    public function __invoke(AfterTransformTextForPersistenceEvent $event): void
+    {
+        // this replace ckeditor 4 configurations:
+        // enterMode: 2 # <br> instead of <p>
+        // autoParagraph: false
+        $config = $event->getProcessingConfiguration();
+        if ((bool)($config['plainRichText'] ?? false) === false) {
+            return;
+        }
+        $content = $event->getHtmlContent();
+        $pattern = '/<p(.*?)>((.*?)+)\<\/p>/';
+        $matches = [];
+        $cnt = preg_match_all($pattern, $content, $matches);
+        if ($cnt > 0) {
+            $event->setHtmlContent(implode('<br>', $matches[2]));
+        }
+    }
+
+}

--- a/Configuration/RTE/Richtextinputfields.yaml
+++ b/Configuration/RTE/Richtextinputfields.yaml
@@ -35,6 +35,8 @@ editor:
 
 processing:
   overruleMode: nothing
+  # v13: autoParagraph: false and enterMode: 2
+  plainRichText: true
   allowTags:
     - sub
     - sup


### PR DESCRIPTION
both configurations autoParagraph: 1 and enterMode: 2 are dropped with CKEditor 5
we introduced an event listener for replace paragraphs for TYPO3 v13