### PR TITLE
!!![TASK] TYPO3 v13 Support only

### DIFF
--- a/Configuration/RTE/Richtextinputfields.yaml
+++ b/Configuration/RTE/Richtextinputfields.yaml
@@ -21,9 +21,6 @@ editor:
       # Filled by Event based on TCA configuration
       # maxCharCount: 255
 
-    autoParagraph: false
-    enterMode: 2 # <br> instead of <p>
-
     extraPlugins:
       - wordcount
       - specialchar
@@ -35,7 +32,6 @@ editor:
 
 processing:
   overruleMode: nothing
-  # v13: autoParagraph: false and enterMode: 2
   plainRichText: true
   allowTags:
     - sub

--- a/composer.json
+++ b/composer.json
@@ -2,15 +2,13 @@
 	"name": "b13/richtextinputfields",
 	"type": "typo3-cms-extension",
 	"description": "Rich text editor for input fields.",
-	"version": "1.1.1",
 	"extra": {
 		"typo3/cms": {
 			"extension-key": "richtextinputfields"
 		}
 	},
 	"require" : {
-		"typo3/cms-rte-ckeditor": "^11.5 || ^12.4 || ^13.4",
-		"php": "^8.1"
+		"typo3/cms-rte-ckeditor": "^13.4"
 	},
 	"autoload": {
 		"psr-4": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -10,7 +10,7 @@ $EM_CONF[$_EXTKEY] = [
     'state' => 'stable',
     'version' => '1.1.1',
     'constraints' => [
-        'depends' => ['typo3' => '11.5.33-13.99.99'],
+        'depends' => ['typo3' => '13.4.5-13.99.99'],
         'conflicts' => [],
         'suggests' => [],
     ],


### PR DESCRIPTION
unfortunaly the extension is broken in v12
because of CKEditor 5 we decide to drop support
for TYPO3 < 13
(v13 has an eventlistener to save input correct)